### PR TITLE
Re-enable dashboard for production. It's not a terrible security risk…

### DIFF
--- a/.ansible/templates/docker-compose.yaml.j2
+++ b/.ansible/templates/docker-compose.yaml.j2
@@ -74,7 +74,7 @@ services:
       restart_policy:
         condition: any
       labels:
-        - traefik.enable={{ (env != 'prod') | string | lower }}
+        - traefik.enable=true
 
         # required in swarm
         - traefik.http.services.api@internal.loadbalancer.server.port=8080


### PR DESCRIPTION
… since the hostname validation is still in affect here, and it would only be accessible with a host header coming in at *.diesel.net